### PR TITLE
add n8n-community-node-package keyword to project

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
     "url": "git+https://github.com/naskio/n8n-nodes-python.git"
   },
   "keywords": [
+    "n8n-community-node-package",
     "n8n",
     "nodemation",
     "nodes",


### PR DESCRIPTION
Makes this project available in n8n community nodes by using the keyword provided by official n8n documentation.